### PR TITLE
Avoid error caused by parsing number to date

### DIFF
--- a/lib/trailblazer/finder/utils/parse.rb
+++ b/lib/trailblazer/finder/utils/parse.rb
@@ -7,11 +7,12 @@ module Trailblazer
       class Parse
         # Need a replacement for this
         def self.date(value)
-          return unless valid_date(value)
+          return unless date?(value)
           Date.parse(value).strftime("%Y-%m-%d")
         end
 
-        def self.valid_date(date)
+        def self.date?(date)
+          return false if date.to_s =~ /^[0-9]+$/
           date_hash = Date._parse(date.to_s)
           Date.valid_date?(date_hash[:year].to_i, date_hash[:mon].to_i, date_hash[:mday].to_i)
         end

--- a/spec/trailblazer/finder/utils/parse_spec.rb
+++ b/spec/trailblazer/finder/utils/parse_spec.rb
@@ -16,6 +16,10 @@ module Trailblazer
           it 'returns nil value is not date worthy' do
             expect(Finder::Utils::Parse.date('Unknown')).to eq nil
           end
+
+          it 'returns nil value is ambiguous like 1215' do
+            expect(Finder::Utils::Parse.date('1215')).to eq nil
+          end
         end
 
         describe '.escape_term' do


### PR DESCRIPTION
**What this PR does / why we need it:**

Avoid error occurring when I pass numbers that Date can parse to filter.
So we need to...

1. skip parsing to Date if value is Number
or 
2. remove parsing like #14 ( simple way )

I prefer 2 to 1 because there is no need to have complexity in Finder.

※ If we decide to remove parsing, Finder::Utils::Parse isn't necessary anymore?

**NOTE: How to reproduce error**:

1. Pass the value seems like date ( like 1001, 1224 etc) to Finder.

```
        actions = {
          min: ->(entity_type, min) { entity_type.select { |v| v > min } },
          max: ->(entity_type, max) { entity_type.select { |v| v < max } }
        }

        finder = Finder::Find.new [1, 2, 3, 4, 5, 1215], { min: 2, max: 1215 }, actions
```

2. 😢 

```
     Failure/Error: max: ->(entity_type, max) { entity_type.select { |v| v < max } }

     ArgumentError:
       comparison of Integer with String failed
     # ./spec/trailblazer/finder/find_spec.rb:33:in `<'
     # ./spec/trailblazer/finder/find_spec.rb:33:in `block (5 levels) in <module:Trailblazer>'
     # ./spec/trailblazer/finder/find_spec.rb:33:in `select'
     # ./spec/trailblazer/finder/find_spec.rb:33:in `block (4 levels) in <module:Trailblazer>'
     # ./lib/trailblazer/finder/find.rb:19:in `instance_exec'
     # ./lib/trailblazer/finder/find.rb:19:in `block in query'
     # ./lib/trailblazer/finder/find.rb:17:in `each'
     # ./lib/trailblazer/finder/find.rb:17:in `inject'
     # ./lib/trailblazer/finder/find.rb:17:in `query'
     # ./spec/trailblazer/finder/find_spec.rb:37:in `block (3 levels) in <module:Trailblazer>'
```