### PR TITLE
Correct rubocop error

### DIFF
--- a/spec/trailblazer/finder/adapters_spec.rb
+++ b/spec/trailblazer/finder/adapters_spec.rb
@@ -77,6 +77,7 @@ module Trailblazer
           end.not_to raise_error
         end
       end
+
       describe FriendlyId do
         it 'can load FriendlyId adapter' do
           expect do


### PR DESCRIPTION
Correcting the error below.

```
Running RuboCop...
Inspecting 75 files
...........................................................C...............
Offenses:
spec/trailblazer/finder/adapters_spec.rb:79:7: C: RSpec/EmptyLineAfterExampleGroup: Add an empty line after describe.
      end
      ^^^
75 files inspected, 1 offense detected
RuboCop failed!
The command "bundle exec rake" exited with 1.
```