### PR TITLE
Finder doesn't work with latest activity gem ( 0.7.1). 

### DIFF
--- a/spec/trailblazer/finder/adapters_spec.rb
+++ b/spec/trailblazer/finder/adapters_spec.rb
@@ -77,6 +77,7 @@ module Trailblazer
           end.not_to raise_error
         end
       end
+
       describe FriendlyId do
         it 'can load FriendlyId adapter' do
           expect do

--- a/trailblazer-finder.gemspec
+++ b/trailblazer-finder.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dm-sqlite-adapter'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'trailblazer', '>= 2.1.0.beta4'
+  spec.add_development_dependency 'trailblazer-activity', '~> 0.4.3'
   spec.add_development_dependency 'rspec_junit_formatter'
 
   spec.required_ruby_version = '>= 2.2.0'


### PR DESCRIPTION
Finder doesn't work with latest activity gem ( 0.7.1). 

The last one to pass the test is 0.4.3. See Change in Trailblazer-Activity API: https://github.com/trailblazer/trailblazer-activity/commit/8f7555064f7dfe121fa006f06546c29a25ca4835#diff-287ba2f923bba9ff36c29ea0abbec158