### PR TITLE
Format ActionController::Parameters to Hash

### DIFF
--- a/lib/trailblazer/finder/activities/prepare_params.rb
+++ b/lib/trailblazer/finder/activities/prepare_params.rb
@@ -15,7 +15,8 @@ module Trailblazer
         end
 
         def set_params(ctx, **)
-          ctx[:params] = ctx[:options][:params] || {}
+          original_params = ctx[:options][:params] || {}
+          ctx[:params] = (original_params.respond_to? :to_unsafe_h) ? original_params.to_unsafe_h : original_params
         end
 
         step :validate_params


### PR DESCRIPTION
### What this PR does / why we need it:

Avoid error occurring when I pass ActionController::Parameters
So we need to use to_unsafe_h to format if needed.