### PR TITLE
fix: remove deprecated usage of Activity::TaskBuilder.Binary

### DIFF
--- a/lib/trailblazer/operation/finder.rb
+++ b/lib/trailblazer/operation/finder.rb
@@ -1,7 +1,7 @@
 module Trailblazer
   class Operation
     def self.Finder(finder_class, action = nil, entity = nil)
-      task = Trailblazer::Activity::TaskBuilder::Binary(Finder.new)
+      task = Trailblazer::Activity::Circuit::TaskAdapter.for_step(Finder.new, binary: true)
       injections = [
         :params,
         {:"finder.class" => ->(*) { finder_class }},


### PR DESCRIPTION
Just before the end of year.

-- NOTE: Trailblazer::Activity::TaskBuilder.Binary is deprecated; use Trailblazer::Activity::Circuit::TaskAdapter.for_step() instead. It will be removed on or after 2023-12.
Trailblazer::Activity::TaskBuilder.Binary