### PR TITLE
feat: remove casting from the finder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['2.7', '3.0', '3.1', '3.2', '3.3']
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4

--- a/lib/trailblazer/finder/find.rb
+++ b/lib/trailblazer/finder/find.rb
@@ -16,7 +16,6 @@ module Trailblazer
 
       def process_filters(ctx)
         @params.reduce(@entity) do |entity, (name, value)|
-          value = Utils::String.to_date(value) if Utils::String.date?(value)
           filter = @filters[name.to_sym] || @filters[name]
           new_entity = ctx.instance_exec entity, filter[:name], value, &filter[:handler]
           new_entity || entity

--- a/lib/trailblazer/finder/utils/string.rb
+++ b/lib/trailblazer/finder/utils/string.rb
@@ -30,21 +30,6 @@ module Trailblazer
             .tr(" ", "_")
             .downcase
         end
-
-        def self.to_date(value)
-          Date.parse(value).strftime("%Y-%m-%d") if date?(value)
-        end
-
-        def self.date?(date)
-          return false unless
-              date.is_a?(::DateTime) ||
-              date.is_a?(::Date) ||
-              date.is_a?(::String)
-          return false if date.is_a?(::String) && date.size == 36 # Ignore uuids that could get casted to dates
-
-          date_hash = ::Date._parse(date.to_s)
-          Date.valid_date?(date_hash[:year].to_i, date_hash[:mon].to_i, date_hash[:mday].to_i)
-        end
       end
     end
   end

--- a/test/support/operations.rb
+++ b/test/support/operations.rb
@@ -24,7 +24,7 @@ module Product::Finders
 
     property :id, type: Types::Integer
     property :name, type: Types::String, sortable: true
-    filter_by :escaped_name, with: :apply_escaped_name
+    filter_by :escaped_name, with: :apply_escaped_name, type: :string
 
     def apply_escaped_name(entity, _attribute, value)
       return if value.blank?

--- a/test/support/operations.rb
+++ b/test/support/operations.rb
@@ -24,7 +24,7 @@ module Product::Finders
 
     property :id, type: Types::Integer
     property :name, type: Types::String, sortable: true
-    filter_by :escaped_name, with: :apply_escaped_name, type: :string
+    filter_by :escaped_name, with: :apply_escaped_name
 
     def apply_escaped_name(entity, _attribute, value)
       return if value.blank?

--- a/test/trailblazer/finder/utils/string_test.rb
+++ b/test/trailblazer/finder/utils/string_test.rb
@@ -20,24 +20,6 @@ module Trailblazer
         assert String.numeric?('1')
       end
 
-      def test_date
-        assert String.date?('2024-01-01')
-        refute String.date?(nil)
-        refute String.date?('random')
-        refute String.date?(1)
-        assert String.date?('2024/01/01')
-        assert String.date?('2024.01.01')
-        assert String.date?('21-12-2024')
-        refute String.date?('0fae2de1-6537-4d36-9cdb-30edf1e37990')
-      end
-
-      def test_to_date
-        assert_equal String.to_date('28/09/2024'), '2024-09-28'
-        assert_equal String.to_date('2024/09/28'), '2024-09-28'
-        assert_equal String.to_date('28 september 2024'), '2024-09-28'
-        assert_nil String.to_date('third month of this year')
-      end
-
       def test_camelize
         assert_equal String.camelize(:paging), 'Paging'
         assert_equal String.camelize(:some_random_test), 'SomeRandomTest'


### PR DESCRIPTION
The casting there turn value like 020202 to 2002-02-02 which make the finder break in some cases

Devs should cast their input before passing it to the finder. The ORM also do automatic casting when possible.

Build failure are unrelated to this change .